### PR TITLE
#2 java 빌드 버전을 1.8로 변경

### DIFF
--- a/jpa-practice/pom.xml
+++ b/jpa-practice/pom.xml
@@ -38,8 +38,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>7</source>
-          <target>7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- 최신 디펜던시들은 1.8 이상부터 가능하기 때문에 변경